### PR TITLE
Updated s_param in Simulation.py to allow it to return complex values

### DIFF
--- a/pyems/simulation.py
+++ b/pyems/simulation.py
@@ -262,10 +262,10 @@ class Simulation:
             self.ports[i].reflected_voltage()
             / self.ports[j].incident_voltage()
         )
-        s = np.abs(s)
         if not dB:
             return s
         else:
+            s = np.abs(s)
             return 20 * np.log10(s)
 
     def _num_ports(self) -> int:


### PR DESCRIPTION
I updated the s_param function in the Simulation class to allow it to pass complex values.  When "dB" is False, instead of taking the absolute value of "s" and returning it, it just returns the complex value.  This is helpful is phase information is desired. 